### PR TITLE
Potential fix for code scanning alert no. 151: Information exposure through an exception

### DIFF
--- a/backend/api/openbao.py
+++ b/backend/api/openbao.py
@@ -673,11 +673,10 @@ def unseal_openbao() -> Dict[str, Any]:
             "status": get_openbao_status(),
         }
     except Exception as e:
+        logger.exception("Exception occurred while unsealing OpenBAO")
         return {
             "success": False,
-            "message": _(
-                "openbao.unseal_error", "Error unsealing OpenBAO: {error}"
-            ).format(error=str(e)),
+            "message": _("openbao.unseal_error", "Error unsealing OpenBAO"),
             "status": get_openbao_status(),
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/151](https://github.com/bceverly/sysmanage/security/code-scanning/151)

**How to fix the problem:**  
To fix the issue, ensure that sensitive information such as raw exception messages is never added to the dictionary returned by `unseal_openbao()`. Instead, on exception, log details server-side and only return a generic error message. This guarantees that no internal information is available in the returned data—even to helper or calling code—eliminating the risk that sensitive data is ever exposed to clients, either directly or by accident.

**Detailed steps:**  
Within the `except Exception as e` block in `unseal_openbao`, do not add the actual exception message (`str(e)`) to the returned dictionary; instead, log the exception and return a response dictionary with only a generic error message. Ensure the logging happens server-side using the configured logger. The code in the API endpoint (`unseal_vault`) can remain as is, as it only reports a sanitized generic error message based on `"success"`.

**What to change:**  
- In `unseal_openbao`, revise the exception handling block (lines 675–682):
  - Remove the `"error"` field containing the stringified exception.
  - Log the exception using the module's `logger`.
  - Return only a generic, non-sensitive message for the `"message"` field, as done for other error cases.
  - Retain returning the status information, if needed.

No changes to methods, imports, or other definitions (beyond possible code within lines shown) are required, as the logger is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
