### PR TITLE
Potential fix for code scanning alert no. 149: Information exposure through an exception

### DIFF
--- a/backend/api/openbao.py
+++ b/backend/api/openbao.py
@@ -490,11 +490,10 @@ def stop_openbao() -> Dict[str, Any]:
             "status": get_openbao_status(),
         }
     except Exception as e:
+        logger.error("Exception occurred while stopping OpenBAO:\n%s", e, exc_info=True)
         return {
             "success": False,
-            "message": _(
-                "openbao.stop_error", "Error stopping OpenBAO: {error}"
-            ).format(error=str(e)),
+            "message": _("openbao.generic_error", "An error occurred while stopping OpenBAO"),
             "status": get_openbao_status(),
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/149](https://github.com/bceverly/sysmanage/security/code-scanning/149)

To fix the problem, we should ensure that sensitive data (including exception details, stack traces, or any internal error strings) are not sent back to API clients. Instead, only generic error messages should be included in API responses, while detailed exception info should be logged server-side for developer diagnostics.

**Best way to fix:**  
- In `stop_openbao`, do not include exception details (such as `str(e)`) inside the returned dictionary's `message` field or anywhere else intended for user consumption.  
- When an exception is caught, log the details server-side using the logger but return only a generic error message to the client.  
- In `stop_server`, assemble the response with only generic, non-sensitive messages in failure cases, not passing through fields originating from exceptions.  
- Ensure no internal error strings or exception details from stop_openbao leak into the HTTP response.  
- No changes to application logic, only error-message management and logging additions.

**Implementation details:**  
- Edit `stop_openbao` so its exception handler logs the exception (using `logger.error(traceback.format_exc())`) and returns a dictionary with a generic message (e.g., "An error occurred while stopping OpenBAO"), never including `str(e)` or any stack trace.  
- In `stop_server`, construct the response for all error cases from known successful/unsuccessful values and generic messages, not passing through potentially tainted fields from `stop_openbao`.

**Changed regions:**  
- Function `stop_openbao`: Edit exception handling/returned value. Add logging.
- No changes to imports needed (`logging` is present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
