### PR TITLE
Potential fix for code scanning alert no. 150: Information exposure through an exception

### DIFF
--- a/backend/api/openbao.py
+++ b/backend/api/openbao.py
@@ -561,7 +561,7 @@ def seal_openbao() -> Dict[str, Any]:
             return {
                 "success": False,
                 "message": _("openbao.seal_failed", "Failed to seal OpenBAO"),
-                "error": result.stderr or result.stdout,
+                # "error": result.stderr or result.stdout,  # Commented out to avoid exposing details
                 "status": get_openbao_status(),
             }
 
@@ -572,13 +572,13 @@ def seal_openbao() -> Dict[str, Any]:
             "status": get_openbao_status(),
         }
     except Exception as e:
+        logger.exception("Exception occurred while sealing OpenBAO")  # Log full traceback for server-side debugging
         return {
             "success": False,
-            "message": _("openbao.seal_error", "Error sealing OpenBAO: {error}").format(
-                error=str(e)
-            ),
+            "message": _("openbao.seal_error", "Error sealing OpenBAO"),
             "status": get_openbao_status(),
         }
+
 
 
 def unseal_openbao() -> Dict[str, Any]:


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/150](https://github.com/bceverly/sysmanage/security/code-scanning/150)

To fully correct the risk of information disclosure, exception details should not be returned in a data structure intended for use in API responses, even if the current API response code attempts sanitization.  

- **General fix:** In backend/api/openbao.py, in the `seal_openbao` function, catch exceptions but avoid returning the actual error or exception string to the caller – only log them server-side. The returned dictionary should always contain only generic error messages and never include exception message content in the `error` field.  
- **Detailed fix:**  
  - In the `except Exception as e:` block of `seal_openbao`, replace the message and `error` value with generic, non-sensitive text, log the exception using `logger.exception`, and ensure the API endpoint continues using/routing only sanitized data.
  - Optionally, review other failure cases (`result.stderr`/`stdout` usage in error returns) to remove detailed output unless it's safe for users.
  - Ensure the fix is limited to `seal_openbao` so as not to alter application functionality nor leak information anywhere else.
- **Needed:**  
  - Use logger to record exception message and traceback.
  - Do not include exception text in returned dicts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
