### PR TITLE
Potential fix for code scanning alert no. 148: Information exposure through an exception

### DIFF
--- a/backend/api/openbao.py
+++ b/backend/api/openbao.py
@@ -319,14 +319,14 @@ def start_openbao() -> Dict[str, Any]:
                         )
 
                 except Exception as e:
-
+                    logger.exception("Failed to run PowerShell script for OpenBAO start")
                     class Result:
-                        def __init__(self, error):
+                        def __init__(self):
                             self.returncode = 1
                             self.stdout = ""
-                            self.stderr = str(error)
+                            self.stderr = _("openbao.start_error", "Internal error occurred while starting OpenBAO")
 
-                    result = Result(e)
+                    result = Result()
             else:
                 # CMD script fallback - avoid shell=True for security
                 result = subprocess.run(  # nosec B607 B603


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/148](https://github.com/bceverly/sysmanage/security/code-scanning/148)

The best way to fix this problem is to ensure that exception details (`str(e)` or a stack trace) are never included in the result objects that are returned to the user interface, particularly in any error message fields. Sensitive error information should be logged for server-side debugging but not included in API responses. In this file:
- Address the Windows PowerShell error path by ensuring `Result.stderr` does not directly expose the full string of `e`.
- Instead, set `stderr` to a generic message, and log the stack trace (`logger.exception(...)`) server-side.
- Confirm that all error output fields (e.g., `result.stderr`, `result.stdout`) in success/failure responses do not propagate sensitive stack traces or exception details.

**What to change:**
- In the PowerShell error handler (lines 321–329), ensure the error in the custom `Result` class uses a generic message (like "Internal server error" or similar) instead of `str(error)` (i.e., `str(e)`).
- Log the stack trace (server-side) for diagnostics, but never expose them to the client.

**What is needed:**
- Add a call to `logger.exception("Failed to run PowerShell script for OpenBAO start")` in the exception handler.
- Replace `self.stderr = str(error)` with a generic message (e.g., `"Internal server error"` or a localized string via `_()`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
