### PR TITLE
Potential fix for code scanning alert no. 148: Information exposure through an exception

### DIFF
--- a/backend/api/openbao.py
+++ b/backend/api/openbao.py
@@ -381,11 +381,10 @@ def start_openbao() -> Dict[str, Any]:
             "status": get_openbao_status(),
         }
     except Exception as e:
+        logger.error("Exception occurred while starting OpenBAO", exc_info=True)
         return {
             "success": False,
-            "message": _(
-                "openbao.start_error", "Error starting OpenBAO: {error}"
-            ).format(error=str(e)),
+            "message": _("openbao.start_error", "An error occurred while starting OpenBAO"),
             "status": get_openbao_status(),
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/148](https://github.com/bceverly/sysmanage/security/code-scanning/148)

The best way to fix the problem is to ensure that any exception details or stack trace information generated in `start_openbao()` do not end up returned to the client, even indirectly. Instead, exception details (such as `str(e)`) should be logged on the server side (using `logger.error()`), and only generic, non-sensitive messages should be set for the user-facing dictionary.

To achieve this:

- In the broad `except Exception as e:` block in `start_openbao()`, log the error (with traceback if appropriate) using the already configured `logger` instead of embedding its string representation in the returned dictionary.
- The returned dictionary's `"message"` for errors should be a generic string, e.g. "An error occurred while starting OpenBAO", with no reference to the exception details.
- No code in `start_openbao()` should ever return exception message contents (such as `str(e)`) to the calling function, and thus not to the client.

This requires updating lines 384–388, and likely adding a call to `logger.error("...")`, possibly including a traceback for debugging. No new external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
