### PR TITLE
Potential fix for code scanning alert no. 153: Clear-text logging of sensitive information

### DIFF
--- a/scripts/_sysmanage_secure_installation.py
+++ b/scripts/_sysmanage_secure_installation.py
@@ -364,7 +364,7 @@ def check_database_connectivity():
                 print("  Generating secure database password...")
                 new_password = generate_secure_db_password()
 
-                print(f"  Updating PostgreSQL password for user '{normalized_config['username']}'...")
+                print("  Updating PostgreSQL password for database user...")
                 if update_postgres_user_password(normalized_config['username'], new_password):
                     # Update the config with new password
                     normalized_config['password'] = new_password


### PR DESCRIPTION
Potential fix for [https://github.com/bceverly/sysmanage/security/code-scanning/153](https://github.com/bceverly/sysmanage/security/code-scanning/153)

To fix the problem, we should avoid logging sensitive information. In this case, we should not log any values that could be sensitive—specifically, the username, which was flagged as potentially tainted by the password value. Therefore, we must change the log line on line 367 so that it does not reveal the specific username being updated, or any other potentially sensitive data. Instead, we should either omit the username or generically refer to the action being taken. Only generic, non-sensitive status messages should be output.

Edit line 367 in scripts/_sysmanage_secure_installation.py to remove the reference to the username variable in the log output, replacing it with a safe, generic statement (e.g., "Updating PostgreSQL password for database user...").

No imports, method changes, or additional definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
